### PR TITLE
Update eodrcpt.hsl

### DIFF
--- a/logging/elasticsearch/eodrcpt.hsl
+++ b/logging/elasticsearch/eodrcpt.hsl
@@ -35,7 +35,7 @@ function sendlog($logdata = []) {
 		"receivedtime" => round($time * 1000)
 	];
 
-	$path = "/".$indexname."-".strftime($indexrotate, $time)."/".$indextype."/".$messageid.":".$actionid;
+	$path = "/".$indexname."-".strftime($indexrotate, $time)."/".$indextype."/".$transaction["id"].":".$actionid;
 	http($elasticurl.$path, $httpoptions, [], json_encode($logdata));
 }
 


### PR DESCRIPTION
I've updated the code to use $transaction["id"] instead of $messageid. $messageid isn't available in eodrcpt so the script failed on 'check code'. 

Several of the scripts are still using $recepient and $sender, might want to look at that. post.hsl is also using $messageid, but the variable is available.

https://support.halon.io/hc/en-us/articles/360002469740
- Search for 'Renamed variables'